### PR TITLE
Add health pack system

### DIFF
--- a/schema/schemas/health-pack.schema.yaml
+++ b/schema/schemas/health-pack.schema.yaml
@@ -1,0 +1,13 @@
+$id: health-pack.schema.yaml
+$schema: https://json-schema.org/draft/2020-12/schema
+description: Coordinates of a health pack
+properties:
+  x:
+    description: X coordinate
+    type: number
+  y:
+    description: Y coordinate
+    type: number
+required:
+  - x
+  - y

--- a/schema/schemas/tick-event-for-bot.schema.yaml
+++ b/schema/schemas/tick-event-for-bot.schema.yaml
@@ -20,8 +20,12 @@ properties:
     type: array
     items:
       $ref: event.schema.yaml
+  healthPack:
+    description: Position of the health pack in this turn
+    $ref: health-pack.schema.yaml
 required:
   - roundNumber
   - botState
   - bulletStates
   - events
+  - healthPack

--- a/schema/schemas/tick-event-for-observer.schema.yaml
+++ b/schema/schemas/tick-event-for-observer.schema.yaml
@@ -22,8 +22,12 @@ properties:
     type: array
     items:
       $ref: event.schema.yaml
+  healthPack:
+    description: Position of the health pack in this turn
+    $ref: health-pack.schema.yaml
 required:
   - roundNumber
   - botStates
   - bulletStates
   - events
+  - healthPack

--- a/server/src/main/kotlin/dev/robocode/tankroyale/server/core/ModelUpdater.kt
+++ b/server/src/main/kotlin/dev/robocode/tankroyale/server/core/ModelUpdater.kt
@@ -7,6 +7,7 @@ import dev.robocode.tankroyale.server.score.ScoreCalculator
 import dev.robocode.tankroyale.server.event.*
 import dev.robocode.tankroyale.server.model.*
 import dev.robocode.tankroyale.server.model.Color.Companion.from
+import dev.robocode.tankroyale.server.model.isPointInsideCircle
 import dev.robocode.tankroyale.server.rules.*
 import dev.robocode.tankroyale.server.score.ScoreTracker
 import dev.robocode.tankroyale.server.Server
@@ -69,6 +70,9 @@ class ModelUpdater(
 
     /** Inactivity counter */
     private var inactivityCounter = 0
+
+    /** Current health pack position */
+    private var healthPack = randomHealthPack()
 
     /** The accumulated results ordered with higher total scores first */
     internal fun getResults() = accumulatedScoreCalculator.getScores()
@@ -149,11 +153,14 @@ class ModelUpdater(
         checkForAndHandleDisabledBots()
         checkAndHandleDefeatedBots()
 
+        checkAndHandleHealthPackPickup()
+
         checkAndHandleRoundOrGameOver()
 
         // Store bot and bullet snapshots
         turn.copyBots(botsMap.values)
         turn.copyBullets(bullets)
+        turn.healthPack = healthPack.toPoint()
 
         // Remove dead bots
         botsMap.values.removeIf(IBot::isDead)
@@ -269,6 +276,17 @@ class ModelUpdater(
         val cellHeight = setup.arenaHeight / gridHeight
 
         return randomBotPoint(occupiedCells, cellCount, gridWidth, cellWidth, cellHeight)
+    }
+
+    /** Returns a random position around the center for spawning a health pack */
+    private fun randomHealthPack(): MutablePoint {
+        val centerX = setup.arenaWidth / 2.0
+        val centerY = setup.arenaHeight / 2.0
+        val rangeX = setup.arenaWidth / 4.0
+        val rangeY = setup.arenaHeight / 4.0
+        val x = centerX + (Math.random() - 0.5) * rangeX
+        val y = centerY + (Math.random() - 0.5) * rangeY
+        return MutablePoint(x, y)
     }
 
     /** Execute bot intents for all bots that are not disabled */
@@ -668,6 +686,16 @@ class ModelUpdater(
         }
 
         scoreTracker.registerDeaths(deadBotIds)
+    }
+
+    /** Checks if any bot picks up the health pack */
+    private fun checkAndHandleHealthPackPickup() {
+        botsMap.values.forEach { bot ->
+            if (bot.isAlive && isPointInsideCircle(bot.position.toPoint(), healthPack, BOT_BOUNDING_CIRCLE_RADIUS)) {
+                bot.changeEnergy(10.0)
+                healthPack = randomHealthPack()
+            }
+        }
     }
 
     /** Cool down and fire guns. */

--- a/server/src/main/kotlin/dev/robocode/tankroyale/server/mapper/PointToHealthPackMapper.kt
+++ b/server/src/main/kotlin/dev/robocode/tankroyale/server/mapper/PointToHealthPackMapper.kt
@@ -1,0 +1,13 @@
+package dev.robocode.tankroyale.server.mapper
+
+import dev.robocode.tankroyale.schema.HealthPack
+import dev.robocode.tankroyale.server.model.IPoint
+
+object PointToHealthPackMapper {
+    fun map(point: IPoint): HealthPack {
+        return HealthPack().apply {
+            x = point.x
+            y = point.y
+        }
+    }
+}

--- a/server/src/main/kotlin/dev/robocode/tankroyale/server/mapper/TurnToTickEventForBotMapper.kt
+++ b/server/src/main/kotlin/dev/robocode/tankroyale/server/mapper/TurnToTickEventForBotMapper.kt
@@ -4,6 +4,7 @@ import dev.robocode.tankroyale.schema.Message
 import dev.robocode.tankroyale.schema.TickEventForBot
 import dev.robocode.tankroyale.server.mapper.BotToBotStateMapper.map
 import dev.robocode.tankroyale.server.mapper.BulletsToBulletStatesMapper.map
+import dev.robocode.tankroyale.server.mapper.PointToHealthPackMapper.map as mapHealth
 import dev.robocode.tankroyale.server.model.BotId
 import dev.robocode.tankroyale.server.model.ITurn
 
@@ -17,6 +18,7 @@ object TurnToTickEventForBotMapper {
             botState = map(bot, enemyCount)
             bulletStates = map(turn.bullets.filter { it.botId == bot.id }.toSet())
             events = EventsMapper.map(turn.getEvents(botId))
+            healthPack = mapHealth(turn.healthPack)
         }
     }
 }

--- a/server/src/main/kotlin/dev/robocode/tankroyale/server/mapper/TurnToTickEventForObserverMapper.kt
+++ b/server/src/main/kotlin/dev/robocode/tankroyale/server/mapper/TurnToTickEventForObserverMapper.kt
@@ -3,6 +3,7 @@ package dev.robocode.tankroyale.server.mapper
 import dev.robocode.tankroyale.schema.Message
 import dev.robocode.tankroyale.schema.Participant
 import dev.robocode.tankroyale.schema.TickEventForObserver
+import dev.robocode.tankroyale.server.mapper.PointToHealthPackMapper.map as mapHealth
 import dev.robocode.tankroyale.server.model.BotId
 import dev.robocode.tankroyale.server.model.ITurn
 import java.util.Collections.unmodifiableList
@@ -22,5 +23,6 @@ object TurnToTickEventForObserverMapper {
             botStates = unmodifiableList(BotsToBotsWithIdMapper.map(turn.bots, participantsMap, enemyCountMap, debugGraphicsEnableMap))
             bulletStates = unmodifiableList(BulletsToBulletStatesMapper.map(turn.bullets))
             events = unmodifiableList(EventsMapper.map(turn.observerEvents))
+            healthPack = mapHealth(turn.healthPack)
         }
 }

--- a/server/src/main/kotlin/dev/robocode/tankroyale/server/model/ITurn.kt
+++ b/server/src/main/kotlin/dev/robocode/tankroyale/server/model/ITurn.kt
@@ -19,6 +19,9 @@ interface ITurn {
     /** Map over bot events  */
     val botEvents: Map<BotId, Set<Event>>
 
+    /** Position of the health pack available in this turn */
+    val healthPack: Point
+
     /**
      * Returns a bot instance by id.
      * @param botId is the id of the bot.

--- a/server/src/main/kotlin/dev/robocode/tankroyale/server/model/MutableTurn.kt
+++ b/server/src/main/kotlin/dev/robocode/tankroyale/server/model/MutableTurn.kt
@@ -19,10 +19,13 @@ data class MutableTurn(
     /** Observer events  */
     override val observerEvents: MutableSet<Event> = mutableSetOf(),
 
-    ) : ITurn {
+    /** Position of the health pack */
+    override var healthPack: Point = Point(0.0, 0.0),
+
+) : ITurn {
 
     /** Returns an immutable copy of this turn */
-    fun toTurn() = Turn(turnNumber, copyBots(), copyBullets(), observerEvents.toSet(), copyBotEvents())
+    fun toTurn() = Turn(turnNumber, copyBots(), copyBullets(), observerEvents.toSet(), copyBotEvents(), healthPack)
 
     /**
      * Adds an observer event.

--- a/server/src/main/kotlin/dev/robocode/tankroyale/server/model/Turn.kt
+++ b/server/src/main/kotlin/dev/robocode/tankroyale/server/model/Turn.kt
@@ -19,4 +19,7 @@ data class Turn(
     /** Map over bot events  */
     override val botEvents: Map<BotId, Set<Event>>,
 
+    /** Position of the health pack */
+    override val healthPack: Point,
+
     ) : ITurn


### PR DESCRIPTION
## Summary
- introduce a `HealthPack` schema describing coordinates
- expose health pack data in tick events for bots and observers
- track a single health pack in `ModelUpdater`
- respawn the pack on pickup and grant 10 energy
- map health pack positions when creating tick events

## Testing
- `./gradlew test` *(fails: cannot find symbol errors)*

------
https://chatgpt.com/codex/tasks/task_e_68548917208c832b93bb443870e88e3c